### PR TITLE
Rename shortname field to name in Quote

### DIFF
--- a/paft-market/src/market/quote.rs
+++ b/paft-market/src/market/quote.rs
@@ -17,8 +17,8 @@ pub struct Quote {
     /// Instrument identifier.
     #[cfg_attr(feature = "dataframe", df_derive(as_string))]
     pub instrument: Instrument,
-    /// Short display name.
-    pub shortname: Option<String>,
+    /// Display name.
+    pub name: Option<String>,
     /// Market price.
     pub price: Option<Money>,
     /// Previous close price.

--- a/paft-market/tests/common.rs
+++ b/paft-market/tests/common.rs
@@ -12,7 +12,7 @@ use paft_money::{Currency, Money};
 pub fn build_quote() -> paft_market::market::quote::Quote {
     paft_market::market::quote::Quote {
         instrument: Instrument::from_symbol("AAPL", AssetKind::Equity).unwrap(),
-        shortname: Some("Apple Inc.".to_string()),
+        name: Some("Apple Inc.".to_string()),
         price: Some(Money::new(Decimal::from(150), Currency::Iso(IsoCurrency::USD)).unwrap()),
         previous_close: Some(
             Money::new(Decimal::from(147), Currency::Iso(IsoCurrency::USD)).unwrap(),
@@ -27,7 +27,7 @@ pub fn build_quote() -> paft_market::market::quote::Quote {
 fn quote_construction_smoke() {
     let quote = Quote {
         instrument: Instrument::from_symbol("AAPL", AssetKind::Equity).unwrap(),
-        shortname: Some("Apple Inc.".to_string()),
+        name: Some("Apple Inc.".to_string()),
         price: Some(Money::new(Decimal::from(150), Currency::Iso(IsoCurrency::USD)).unwrap()),
         previous_close: Some(
             Money::new(

--- a/paft-market/tests/dataframe.rs
+++ b/paft-market/tests/dataframe.rs
@@ -48,7 +48,7 @@ fn search_result_to_dataframe() {
 fn vec_quote_to_dataframe_smoke() {
     let quotes = [Quote {
         instrument: Instrument::from_symbol("AAPL", AssetKind::Equity).unwrap(),
-        shortname: Some("Apple Inc.".to_string()),
+        name: Some("Apple Inc.".to_string()),
         price: Some(usd(150)),
         previous_close: Some(usd(147)),
         day_volume: None,
@@ -65,7 +65,7 @@ fn vec_quote_to_dataframe_smoke() {
 fn quote_to_dataframe_smoke() {
     let quote = Quote {
         instrument: Instrument::from_symbol("AAPL", AssetKind::Equity).unwrap(),
-        shortname: Some("Apple Inc.".to_string()),
+        name: Some("Apple Inc.".to_string()),
         price: Some(usd(150)),
         previous_close: Some(usd(147)),
         day_volume: None,

--- a/paft-market/tests/quote.rs
+++ b/paft-market/tests/quote.rs
@@ -14,7 +14,7 @@ use std::str::FromStr;
 fn quote_construction() {
     let quote = Quote {
         instrument: Instrument::from_symbol("AAPL", AssetKind::Equity).unwrap(),
-        shortname: Some("Apple Inc.".to_string()),
+        name: Some("Apple Inc.".to_string()),
         price: Some(Money::new(Decimal::from(150), Currency::Iso(IsoCurrency::USD)).unwrap()),
         previous_close: Some(
             Money::new(
@@ -29,7 +29,7 @@ fn quote_construction() {
     };
 
     assert_eq!(quote.instrument.unique_key().as_ref(), "AAPL");
-    assert_eq!(quote.shortname, Some("Apple Inc.".to_string()));
+    assert_eq!(quote.name, Some("Apple Inc.".to_string()));
     assert_eq!(
         quote.price,
         Some(Money::new(Decimal::from(150), Currency::Iso(IsoCurrency::USD)).unwrap())
@@ -52,7 +52,7 @@ fn quote_construction() {
 fn quote_minimal_construction() {
     let quote = Quote {
         instrument: Instrument::from_symbol("AAPL", AssetKind::Equity).unwrap(),
-        shortname: None,
+        name: None,
         price: None,
         previous_close: None,
         day_volume: None,
@@ -60,7 +60,7 @@ fn quote_minimal_construction() {
         market_state: None,
     };
     assert_eq!(quote.instrument.unique_key().as_ref(), "AAPL");
-    assert!(quote.shortname.is_none());
+    assert!(quote.name.is_none());
     assert!(quote.price.is_none());
     assert!(quote.previous_close.is_none());
     assert!(quote.exchange.is_none());
@@ -71,7 +71,7 @@ fn quote_minimal_construction() {
 fn quote_clone() {
     let original = Quote {
         instrument: Instrument::from_symbol("AAPL", AssetKind::Equity).unwrap(),
-        shortname: Some("Apple Inc.".to_string()),
+        name: Some("Apple Inc.".to_string()),
         price: Some(Money::new(Decimal::from(150), Currency::Iso(IsoCurrency::USD)).unwrap()),
         previous_close: Some(
             Money::new(
@@ -93,7 +93,7 @@ fn quote_clone() {
 fn quote_debug_formatting() {
     let quote = Quote {
         instrument: Instrument::from_symbol("AAPL", AssetKind::Equity).unwrap(),
-        shortname: Some("Apple Inc.".to_string()),
+        name: Some("Apple Inc.".to_string()),
         price: Some(Money::new(Decimal::from(150), Currency::Iso(IsoCurrency::USD)).unwrap()),
         previous_close: Some(
             Money::new(
@@ -117,7 +117,7 @@ fn quote_currency_consistency() {
     // Test that currency is embedded in Money fields
     let quote = Quote {
         instrument: Instrument::from_symbol("AAPL", AssetKind::Equity).unwrap(),
-        shortname: Some("Apple Inc.".to_string()),
+        name: Some("Apple Inc.".to_string()),
         price: Some(Money::new(Decimal::from(150), Currency::Iso(IsoCurrency::USD)).unwrap()),
         previous_close: Some(
             Money::new(
@@ -147,7 +147,7 @@ fn quote_currency_none() {
     // Test that when no Money fields are present, currency access returns None
     let quote = Quote {
         instrument: Instrument::from_symbol("AAPL", AssetKind::Equity).unwrap(),
-        shortname: Some("Apple Inc.".to_string()),
+        name: Some("Apple Inc.".to_string()),
         price: None, // No price fields
         previous_close: None,
         day_volume: None,
@@ -165,7 +165,7 @@ fn quote_money_fields() {
     // Test that Money fields work correctly
     let quote = Quote {
         instrument: Instrument::from_symbol("AAPL", AssetKind::Equity).unwrap(),
-        shortname: None,
+        name: None,
         price: Some(Money::new(Decimal::from(150), Currency::Iso(IsoCurrency::USD)).unwrap()),
         previous_close: Some(
             Money::new(Decimal::from(147), Currency::Iso(IsoCurrency::USD)).unwrap(),
@@ -191,7 +191,7 @@ fn quote_money_fields() {
     // Test with None prices
     let quote_no_prices = Quote {
         instrument: Instrument::from_symbol("AAPL", AssetKind::Equity).unwrap(),
-        shortname: None,
+        name: None,
         price: None,
         previous_close: None,
         day_volume: None,
@@ -310,7 +310,7 @@ fn quote_update_debug_formatting() {
 fn quote_serialization() {
     let quote = Quote {
         instrument: Instrument::from_symbol("AAPL", AssetKind::Equity).unwrap(),
-        shortname: Some("Apple Inc.".to_string()),
+        name: Some("Apple Inc.".to_string()),
         price: Some(Money::new(Decimal::from(150), Currency::Iso(IsoCurrency::USD)).unwrap()),
         previous_close: Some(
             Money::new(
@@ -333,7 +333,7 @@ fn quote_serialization() {
 fn quote_with_none_fields() {
     let quote = Quote {
         instrument: Instrument::from_symbol("AAPL", AssetKind::Equity).unwrap(),
-        shortname: None,
+        name: None,
         price: Some(Money::new(Decimal::from(150), Currency::Iso(IsoCurrency::USD)).unwrap()),
         previous_close: Some(
             Money::new(Decimal::from(147), Currency::Iso(IsoCurrency::USD)).unwrap(),
@@ -388,7 +388,7 @@ fn quote_update_with_none_fields() {
 fn serialization_roundtrip_preserves_precision() {
     let quote = Quote {
         instrument: Instrument::from_symbol("AAPL", AssetKind::Equity).unwrap(),
-        shortname: Some("Apple Inc.".to_string()),
+        name: Some("Apple Inc.".to_string()),
         price: Some(
             Money::new(
                 Decimal::from_str("150.123456789").unwrap(),
@@ -422,7 +422,7 @@ fn deserialization_handles_missing_optional_fields() {
     // Test that missing optional fields are handled gracefully via roundtrip
     let quote = Quote {
         instrument: Instrument::from_symbol("AAPL", AssetKind::Equity).unwrap(),
-        shortname: None,
+        name: None,
         price: Some(Money::new(Decimal::from(150), Currency::Iso(IsoCurrency::USD)).unwrap()),
         previous_close: None,
         day_volume: None,

--- a/paft/README.md
+++ b/paft/README.md
@@ -99,7 +99,7 @@ let bitcoin = Instrument::from_symbol("BTC-USD", AssetKind::Crypto)
 // Create market data
 let quote = Quote {
     symbol: Symbol::new("AAPL").unwrap(),
-    shortname: Some("Apple Inc.".to_string()),
+    name: Some("Apple Inc.".to_string()),
     price: Some(Money::from_canonical_str("190.12", Currency::Iso(IsoCurrency::USD)).unwrap()),
     previous_close: Some(Money::from_canonical_str("189.96", Currency::Iso(IsoCurrency::USD)).unwrap()),
     exchange: Some(Exchange::NASDAQ),

--- a/paft/tests/integration.rs
+++ b/paft/tests/integration.rs
@@ -96,7 +96,7 @@ fn end_to_end_workflow() {
     // 5. Create a quote
     let quote = Quote {
         instrument: Instrument::from_symbol("AAPL", AssetKind::Equity).unwrap(),
-        shortname: Some("Apple Inc.".to_string()),
+        name: Some("Apple Inc.".to_string()),
         price: Some(Money::new(Decimal::from(105), Currency::Iso(IsoCurrency::USD)).unwrap()),
         previous_close: Some(
             Money::new(Decimal::from(100), Currency::Iso(IsoCurrency::USD)).unwrap(),
@@ -206,7 +206,7 @@ fn serialization_workflow() {
     // 3. Create and serialize a quote
     let quote = Quote {
         instrument: Instrument::from_symbol("AAPL", AssetKind::Equity).unwrap(),
-        shortname: Some("Apple Inc.".to_string()),
+        name: Some("Apple Inc.".to_string()),
         price: Some(Money::new(Decimal::from(150), Currency::Iso(IsoCurrency::USD)).unwrap()),
         previous_close: Some(
             Money::new(


### PR DESCRIPTION
## Summary

Since the `Quote` struct only provides a single name field, `shortname` is unnecessary and verbose, `name` is more concise. Although some providers return both a longname & shortname (eg. Yahoo Finance), some do not (eg. Alpha Vantage). Hence, `name` is canonical and clearer. 

I am aware this breaking change is very minor, but this rename is prerequisite for a PR I'm preparing on yfinance-rs, which depends on this crate. I'll update the field reference there as part of that PR once this is merged.

## Testing

- `just test` passed.
- `just lint` passed.

```
Summary [   0.555s] 278 tests run: 278 passed, 0 skipped
```